### PR TITLE
Edit sidedrawer width to responsive on mobile 

### DIFF
--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -69,7 +69,7 @@ const Header = ({ isMobile }) => {
               </MuiNextLink>
 
               <Navbar navLinks={navLinks} />  
-              <SideDrawer navLinks={navLinks} />
+              <SideDrawer navLinks={navLinks} isMobile={isMobile}/>
             </Container>
           </Toolbar>
         </AppBar>

--- a/components/SideDrawer.jsx
+++ b/components/SideDrawer.jsx
@@ -12,7 +12,7 @@ import SwipeableDrawer from '@mui/material/SwipeableDrawer';
 // import Drawer from '@mui/material/Drawer';
 // import { flexbox } from '@mui/system';
 
-const SideDrawer = ({ navLinks}) => {
+const SideDrawer = ({ navLinks, isMobile}) => {
   const [state, setState] = useState({
     right: false,
   });
@@ -354,7 +354,8 @@ const SideDrawer = ({ navLinks}) => {
           '.MuiDrawer-paper': {
             bgcolor: 'primary.main',
             width:  '100%' ,
-            maxWidth: 375,
+            maxWidth: isMobile ? 'auto': 375,
+            // maxWidth: 375,
             //display: { md: `none` }
             maxHeight: 812,
           },


### PR DESCRIPTION
Edit side drawer width to responsive on mobile 
when it is smaller than 900px the width will be full. 
<img width="435" alt="image" src="https://user-images.githubusercontent.com/77215789/161402596-e17d0af6-677f-4945-bf0e-e4af3a34004b.png">
<img width="631" alt="image" src="https://user-images.githubusercontent.com/77215789/161402608-918dda74-7a59-452d-8499-18772ed6d3aa.png">
<img width="726" alt="image" src="https://user-images.githubusercontent.com/77215789/161402613-7523b6f6-f66e-4c02-922a-82aada5281d1.png">
